### PR TITLE
[Fix] Paper function is call with theme parameter

### DIFF
--- a/src/theme/overrides/index.js
+++ b/src/theme/overrides/index.js
@@ -16,7 +16,7 @@ export default function ComponentsOverrides(theme) {
     Card(theme),
     Table(theme),
     Input(theme),
-    Paper(theme),
+    Paper(),
     Button(theme),
     Tooltip(theme),
     Backdrop(theme),


### PR DESCRIPTION
## Problem

`Paper()` function is called with `theme` as parameter even though it takes no parameters